### PR TITLE
Add Dependabot configuration for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Configured Dependabot for version updates with a weekly schedule.

# Opening a PR?

## Yop, did you

- [ ] Updated the scripts but forgot to update `SCRIPTS_VERSION`?
- [ ] Update the bw cli version in `VERSION` file but forgot `make sync-helm`?
- [ ] Update the scripts version in `SCRIPTS_VERSION` file but forgot `make sync-helm`?

## Actually, why the PR?
