### PR TITLE
Removing SHA check

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -11,13 +11,10 @@ FROM base AS builder
 ARG BW_CLI_VERSION
 ENV BASE_URL="https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}"
 ENV PKG="bw-linux-${BW_CLI_VERSION}.zip"
-ENV SHA_FILE="bw-linux-sha256-${BW_CLI_VERSION}.txt"
 ENV DOWNLOAD_URL="${BASE_URL}/${PKG}"
-ENV SHA_URL="${BASE_URL}/${SHA_FILE}"
 
 RUN apt-get update && apt-get install -y unzip && \
     curl -s -L -o "/tmp/${PKG}" "${DOWNLOAD_URL}" && \
-    curl -s -L -o "/tmp/${SHA_FILE}" "${SHA_URL}" && \
     unzip /tmp/${PKG} -d /bw-cli && chmod +x /bw-cli/bw
 
 FROM base AS app


### PR DESCRIPTION
# Opening a PR?

## Yop, did you

- [x] Updated the scripts but forgot to update `SCRIPTS_VERSION`?
- [ ] Update the bw cli version in `VERSION` file but forgot `make sync-helm`?
- [ ] Update the scripts version in `SCRIPTS_VERSION` file but forgot `make sync-helm`?

## Actually, why the PR?
BW cli no longer has SHA, can't verify it :(